### PR TITLE
データベース 設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,40 @@
-# README
+# ChatSpace DB設計
+## usersテーブル
+|Column|Type|Option|
+|------|----|------|
+|name|string|null: false, index: true|
+|email|string|null: false|
+|password|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :groups, through: :groups_users
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## messagesテーブル
+|Column|Type|Option|
+|------|----|------|
+|body|text|null: false|
+|image|text||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
 
-Things you may want to cover:
+## groupsテーブル
+|Column|Type|Option|
+|------|----|------|
+|group_name|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :users, through: :groups_users
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## groups_usersテーブル
+|Column|Type|Option|
+|------|----|------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## messagesテーブル
 |Column|Type|Option|
 |------|----|------|
-|body|text|null: false|
+|body|text||
 |image|text||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
@@ -24,7 +24,7 @@
 ## groupsテーブル
 |Column|Type|Option|
 |------|----|------|
-|group_name|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :messages
 - has_many :groups_users


### PR DESCRIPTION
# What
README.mdにデータベース 設計を記載。
users、messages、groups、groups_usersの4つのテーブルを想定。
users.nameにindexを張る。
messages.imageにnullを許可。

# Why
ChatSpaceにはユーザー登録機能、メッセージ投稿機能、チャットグループ作成機能が必要。また、ユーザーとグループには多対多の関係があるので、中間テーブルを含めた4つのテーブルが要ると判断した。
チャットグループメンバー検索機能を作るので、users.nameには検索速度向上のためにindexを張る。
メッセージに画像の添付は必須ではないため、messages.imageにnullを許可。